### PR TITLE
Split savings and investments into 2 different categories

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -32,6 +32,7 @@ class ExpenseForm(FlaskForm):
             ("needs", "Essential Needs"),
             ("wants", "Lifestyle & Wants"),
             ("savings", "Savings & Investments"),
+            ("investments", "Investments"),  
         ],
     )
     date = DateField("Transaction Date", format="%Y-%m-%d", validators=[DataRequired()])
@@ -39,6 +40,8 @@ class ExpenseForm(FlaskForm):
 
 
 class BudgetSettingsForm(FlaskForm):
-    needs_percentage = FloatField("What percentage of your income do you want to allocate for Essential Needs (e.g., housing, food)?", default=50.0, validators=[DataRequired()])
-    savings_percentage = FloatField("What percentage of your income do you want to allocate for Savings & Investments?", default=20.0, validators=[DataRequired()])
+    needs_percentage = FloatField("Essential Needs (%)", default=50.0, validators=[DataRequired()])
+    wants_percentage = FloatField("Wants (%)", default=20.0, validators=[DataRequired()])
+    savings_percentage = FloatField("Savings (%)", default=20.0, validators=[DataRequired()])
+    investments_percentage = FloatField("Investments (%)", default=10.0, validators=[DataRequired()])
     submit = SubmitField("Save Settings")

--- a/app/routes.py
+++ b/app/routes.py
@@ -270,9 +270,9 @@ def budget_settings():
     # Load current settings if they exist
     user_settings = mongo.db.users.find_one({"_id": ObjectId(current_user.get_id())})
     if user_settings and "budget_settings" in user_settings:
-        form.needs_percentage.data = round(user_settings["budget_settings"]["needs"], 2)
+        form.needs_percentage.data = round(user_settings["budget_settings"].get("needs", 0), 2)
         form.wants_percentage.data = round(user_settings["budget_settings"].get("wants", 0), 2)
-        form.savings_percentage.data = round(user_settings["budget_settings"]["savings"], 2)
+        form.savings_percentage.data = round(user_settings["budget_settings"].get("savings", 0), 2)
         form.investments_percentage.data = round(user_settings["budget_settings"].get("investments", 0), 2)
 
     return render_template("budget_settings.html", form=form)

--- a/app/templates/budget_settings.html
+++ b/app/templates/budget_settings.html
@@ -3,18 +3,43 @@
 {% block content %}
 <div class="container mx-auto py-8">
     <h2 class="text-3xl font-bold mb-4">Budget Settings</h2>
-    <form method="POST">
+    <form method="POST" id="budget-form">
         {{ form.hidden_tag() }}
         <div class="mb-4">
             {{ form.needs_percentage.label(class="block text-sm font-medium text-gray-700") }}
-            {{ form.needs_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md") }}
+            {{ form.needs_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", oninput="updateInvestments()") }}
+        </div>
+        <div class="mb-4">
+            {{ form.wants_percentage.label(class="block text-sm font-medium text-gray-700") }}
+            {{ form.wants_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", oninput="updateInvestments()") }}
         </div>
         <div class="mb-4">
             {{ form.savings_percentage.label(class="block text-sm font-medium text-gray-700") }}
-            {{ form.savings_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md") }}
+            {{ form.savings_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", oninput="updateInvestments()") }}
         </div>
-        <p class="text-sm text-gray-600 mb-4">The percentage allocated for Lifestyle & Wants will be automatically calculated based on your inputs for other 2 categories.</p>
+        <div class="mb-4">
+            {{ form.investments_percentage.label(class="block text-sm font-medium text-gray-700") }}
+            {{ form.investments_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", readonly=True) }}
+        </div>
         <button type="submit" class="w-full bg-blue-500 text-white py-2 rounded-md hover:bg-blue-600">Save Settings</button>
     </form>
+</div>
+
+<script>
+    function updateInvestments() {
+        const needs = parseFloat(document.getElementById('needs_percentage').value) || 0;
+        const wants = parseFloat(document.getElementById('wants_percentage').value) || 0;
+        const savings = parseFloat(document.getElementById('savings_percentage').value) || 0;
+        const investments = 100 - needs - wants - savings;
+        
+        // Update the wants percentage field
+        document.getElementById('investments_percentage').value = investments >= 0 ? investments.toFixed(2) : 0; // Ensure it doesn't go negative
+
+        // Check for total exceeding 100%
+        if (investments < 0) {
+            alert("The total percentages cannot exceed 100%. Please adjust your inputs.");
+        }
+    }
+</script>
 </div>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,7 +36,8 @@
                 <select name="category" class="flex-1 p-2 border border-gray-300 rounded-md" required>
                     <option value="needs" {% if expense['category'] == 'needs' %}selected{% endif %}>Essential Needs</option>
                     <option value="wants" {% if expense['category'] == 'wants' %}selected{% endif %}>Lifestyle & Wants</option>
-                    <option value="savings" {% if expense['category'] == 'savings' %}selected{% endif %}>Savings & Investments</option>
+                    <option value="savings" {% if expense['category'] == 'savings' %}selected{% endif %}>Savings</option>
+                    <option value="investments" {% if expense['category'] == 'investments' %}selected{% endif %}>Investments</option>
                 </select>
 
                 <input type="date" name="date" value="{{ expense['date'] }}" class="flex-1 p-2 border border-gray-300 rounded-md" required>

--- a/app/templates/onboarding_step1.html
+++ b/app/templates/onboarding_step1.html
@@ -2,18 +2,29 @@
 
 {% block content %}
 <div class="container mx-auto py-8">
-    <h2 class="text-3xl font-bold mb-4">Set Your Budget Settings</h2>
-    <p class="mb-4">Please enter your budget for needs and savings.</p>
+    <h2 class="text-3xl font-bold mb-4">Set Your Budget Preferences</h2>
+    <p class="mb-4">Allocate percentages of your income for each category. The Investments percentage will be calculated automatically.</p>
 
-    <form method="POST">
+    <form method="POST" id="budget-form">
+        {{ form.hidden_tag() }}
+
         <div class="mb-4">
-            <label for="budget_needs" class="block text-sm font-medium text-gray-700">What percentage of your income do you want to allocate for Essential Needs (e.g., housing, food)?</label>
-            <input type="float" name="budget_needs" id="budget_needs" required class="mt-1 block w-full p-2 border border-gray-300 rounded-md" placeholder="Enter your expected percentage for Essential Needs">
+            {{ form.needs_percentage.label(class="block text-sm font-medium text-gray-700") }}
+            {{ form.needs_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", oninput="updateInvestments()") }}
         </div>
         <div class="mb-4">
-            <label for="budget_savings" class="block text-sm font-medium text-gray-700">What percentage of your income do you want to allocate for Savings & Investments?</label>
-            <input type="float" name="budget_savings" id="budget_savings" required class="mt-1 block w-full p-2 border border-gray-300 rounded-md" placeholder="Enter your expected percentage for Savings & Investments">
+            {{ form.wants_percentage.label(class="block text-sm font-medium text-gray-700") }}
+            {{ form.wants_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", oninput="updateInvestments()") }}
         </div>
+        <div class="mb-4">
+            {{ form.savings_percentage.label(class="block text-sm font-medium text-gray-700") }}
+            {{ form.savings_percentage(class="mt-1 block w-full p-2 border border-gray-300 rounded-md", oninput="updateInvestments()") }}
+        </div>
+        <div class="mb-4">
+            <label for="investments_percentage" class="block text-sm font-medium text-gray-700">Investments (Auto-Calculated)</label>
+            <input type="text" id="investments_percentage" class="mt-1 block w-full p-2 border border-gray-300 rounded-md bg-gray-100" readonly>
+        </div>
+
         <button type="submit" class="w-full bg-blue-500 text-white py-2 rounded-md hover:bg-blue-600">Next</button>
     </form>
 
@@ -21,4 +32,19 @@
         <a href="{{ url_for('index') }}" class="text-blue-500">Skip Onboarding</a>
     </div>
 </div>
+
+<script>
+    function updateInvestments() {
+        const needs = parseFloat(document.getElementById('{{ form.needs_percentage.id }}').value) || 0;
+        const wants = parseFloat(document.getElementById('{{ form.wants_percentage.id }}').value) || 0;
+        const savings = parseFloat(document.getElementById('{{ form.savings_percentage.id }}').value) || 0;
+        const investments = 100 - needs - wants - savings;
+        
+        const investmentsField = document.getElementById("investments_percentage");
+
+        investmentsField.value = investments >= 0 ? investments.toFixed(2) : 0;
+    }
+
+    document.addEventListener("DOMContentLoaded", updateInvestments);
+</script>
 {% endblock %}

--- a/app/templates/summary.html
+++ b/app/templates/summary.html
@@ -73,6 +73,11 @@
                     <div class="mt-1 text-lg font-semibold text-gray-900" id="savingsPercentage">--%</div>
                     <div class="text-xs text-gray-600" id="savingsAmount">$0.00</div>
                 </div>
+                <div class="text-center">
+                    <div class="text-sm font-medium text-gray-500">Investments ({{ budget_settings.investments }}%)</div>
+                    <div class="mt-1 text-lg font-semibold text-gray-900" id="investmentsPercentage">--%</div>
+                    <div class="text-xs text-gray-600" id="investmentsAmount">$0.00</div>
+                </div>
             </div>
         </div>
     </div>
@@ -138,7 +143,8 @@
                     backgroundColor: [
                         'rgb(59, 130, 246)',  // Blue
                         'rgb(16, 185, 129)',  // Green
-                        'rgb(245, 158, 11)'   // Yellow
+                        'rgb(245, 158, 11)',   // Yellow
+                        'rgb(139, 92, 246)'   // Purple
                     ]
                 }]
             },
@@ -238,7 +244,8 @@
         const guidelines = {
             needs: {{ budget_settings.needs }},
             wants: {{ budget_settings.wants }},
-            savings: {{ budget_settings.savings }}
+            savings: {{ budget_settings.savings }},
+            investments: {{ budget_settings.investments }}
         };
 
         function updateBudgetGuidelines(filteredData) {
@@ -246,7 +253,8 @@
             const amounts = {
                 needs: 0,
                 wants: 0,
-                savings: 0
+                savings: 0,
+                investments: 0
             };
 
             filteredData.labels.forEach((category, index) => {
@@ -264,7 +272,7 @@
                 element.classList.remove('text-green-600', 'text-red-600');
                 
                 // Use the user-defined percentages for color coding
-                if (category === 'savings') {
+                if (category === 'savings' || category === 'investments') {
                     element.classList.add(percentage >= guidelines[category] ? 'text-green-600' : 'text-red-600');
                 } else {
                     element.classList.add(percentage <= guidelines[category] ? 'text-green-600' : 'text-red-600');


### PR DESCRIPTION
## Description
This pull request splits the previously defined section of "Savings and Investments: into 2 different ones - "Savings" and "Investments: enhancing the user experience by allowing them to separate their budget for those 2 different categories. Additionally, the process of manually splitting your expenses by categories in percentages has been enhanced by all of the categories being shown, with the investment one being calculated as 100 minus all the other ones.

## Changes
### Investment category:
- Users can now separate their "Savings and Investments" into 2 separate categories.
- The investment category follows the conventions defined before - it is included in the summary chat and has a red/green indicator to reflect whether the appropriate spending is aligned with the user's expectations.

### Setting up the budget settings:
- Instead of leaving the user wondering what the expected 4th percentage should be for the remaining category when splitting their expenses, we are going to show the remaining percentage portion in real life. The 4th category that would be changing dynamically is "Investments". In case the user has 3 other categories with a sum exceeding 100, the system will notify the user and won't accept the budget setting change. 
- The same convention is followed in onboarding step 1.